### PR TITLE
Updates from danielparks-template.rs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,40 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-added-large-files
+        args: ["--maxkb=1024"]
+      - id: check-case-conflict
+      - id: check-executables-have-shebangs
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-shebang-scripts-are-executable
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-vcs-permalinks
+      - id: check-xml
+      - id: check-yaml
+      - id: detect-private-key
+      - id: mixed-line-ending
+        args: ["--fix=no"]
+      - id: no-commit-to-branch
+  - repo: local
+    hooks:
+      - id: cargo clippy
+        name: cargo clippy
+        language: system
+        entry: cargo clippy --all-targets --all-features
+        files: (\.rs|Cargo\.toml)$
+        pass_filenames: false
+      - id: cargo doc
+        name: cargo doc
+        language: system
+        entry: sh -c 'RUSTDOCFLAGS=-Dwarnings cargo doc --all-features --no-deps --document-private-items'
+        files: \.rs$
+        pass_filenames: false
+      - id: cargo fmt
+        name: cargo fmt
+        language: system
+        entry: cargo fmt --check
+        files: (\.rs|rustfmt\.toml)$
+        pass_filenames: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ pedantic = { level = "warn", priority = -1 }
 missing_docs_in_private_items = "warn"
 
 # Other restriction lints
+allow_attributes = "warn"
+allow_attributes_without_reason = "warn"
 arithmetic_side_effects = "warn"
 as_underscore = "warn"
 assertions_on_result_states = "warn"

--- a/deny.toml
+++ b/deny.toml
@@ -13,6 +13,7 @@ allow = [
   "CDLA-Permissive-2.0",
   "ISC",
   "MIT",
+  "MPL-2.0",
   "Unicode-3.0",
   "Unicode-DFS-2016",
   "Unlicense",

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,7 +250,7 @@ fn render_html<S: AsRef<str>>(
 }
 
 /// Print a pretty diff.
-#[allow(clippy::iter_with_drain)] // Lint is incorrect
+#[expect(clippy::iter_with_drain, reason = "lint is incorrect")]
 fn print_pretty_diff<S>(out: &mut S, old: &str, new: &str)
 where
     S: termcolor::WriteColor + io::Write,
@@ -292,7 +292,10 @@ where
             diff::Result::Both(line, _) => {
                 if let Some(count) = lines_since_diff {
                     println!(" {line}");
-                    #[allow(clippy::arithmetic_side_effects)]
+                    #[expect(
+                        clippy::arithmetic_side_effects,
+                        reason = "limited by CONTEXT_LEN"
+                    )]
                     let count = count + 1;
                     if count >= CONTEXT_LEN {
                         lines_since_diff = None;


### PR DESCRIPTION
- **`cargo deny`: allow MPL-2.0 weak copyleft license (match template).**
  

- **Add `prek` (or `pre-commit`) configuration for pre-commit hooks.**
  

- **Lints: prefer `#[expect(..., reason = "...")]`.**
  