### PR TITLE
Security: bump aws-lc-* versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## main branch
 
+### Security
+
+* Multiple security vulnerabilities in [aws-lc-rs] again. Monitorbot does not use the crate directly, but it appears to be used by [rustls] for TLS. At worst, the vulnerability might allow someone to spoof a TLS-authenticated site.
+
+  * [GHSA-394x-vwmw-crm3]: AWS-LC X.509 Name Constraints Bypass via Wildcard/Unicode CN
+  * [GHSA-9f94-5g5w-gf6r]: CRL Distribution Point Scope Check Logic Error in AWS-LC
+
+[aws-lc-rs]: https://github.com/aws/aws-lc-rs/
+[rustls]: https://github.com/rustls/rustls
+[GHSA-394x-vwmw-crm3]: https://github.com/advisories/GHSA-394x-vwmw-crm3
+[GHSA-9f94-5g5w-gf6r]: https://github.com/advisories/GHSA-9f94-5g5w-gf6r
+
 ## Release 0.0.2 (2026-03-05)
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,9 +144,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",
@@ -1461,9 +1461,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
Multiple security vulnerabilities in [aws-lc-rs] again. Monitorbot does not use the crate directly, but it appears to be used by [rustls] for TLS. At worst, the vulnerability might allow someone to spoof a TLS-authenticated site.

  * [GHSA-394x-vwmw-crm3]: AWS-LC X.509 Name Constraints Bypass via Wildcard/Unicode CN
  * [GHSA-9f94-5g5w-gf6r]: CRL Distribution Point Scope Check Logic Error in AWS-LC

[aws-lc-rs]: https://github.com/aws/aws-lc-rs/
[rustls]: https://github.com/rustls/rustls
[GHSA-394x-vwmw-crm3]: https://github.com/advisories/GHSA-394x-vwmw-crm3
[GHSA-9f94-5g5w-gf6r]: https://github.com/advisories/GHSA-9f94-5g5w-gf6r
