### PR TITLE
Handle bad state, i.e. old responses, by warning and ignoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## main branch
 
 * Write state atomically.
+* If we fail to read state, i.e. old response information, print a warning and treat it as if there was no old response.
 * Bump MSRV to 1.91 for `Path::with_added_extension()`.
 
 ## Release 0.0.3 (2026-03-20)

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,13 @@ async fn cli(params: &Params) -> anyhow::Result<ExitCode> {
         let request_path = state_dir_path.join(file_name);
 
         let old_response: Option<Response> = if request_path.exists() {
-            Some(ron::de::from_bytes(&std::fs::read(&request_path)?)?)
+            match load_old_response(&request_path) {
+                Ok(response) => Some(response),
+                Err(error) => {
+                    tracing::warn!("Could not read old response: {error:?}");
+                    None
+                }
+            }
         } else {
             None
         };
@@ -229,6 +235,15 @@ async fn cli(params: &Params) -> anyhow::Result<ExitCode> {
     }
 
     Ok(ExitCode::SUCCESS)
+}
+
+/// Load old response.
+///
+/// # Errors
+///
+/// May return an error from [`fs::read()`] or from [`ron::de::from_bytes()`].
+fn load_old_response(request_path: &Path) -> anyhow::Result<Response> {
+    Ok(ron::de::from_bytes(&std::fs::read(request_path)?)?)
 }
 
 /// Deal with a caching a redirect.


### PR DESCRIPTION
Previously it would just fail and the same problem would occur on the
next run.
